### PR TITLE
Fix 06b stale GCS snapshot: read table from config_year.yml

### DIFF
--- a/src/06b_output_wildfire.R
+++ b/src/06b_output_wildfire.R
@@ -63,6 +63,9 @@ options(scipen = 999)
 # This will automatically look for a file named config.yml in the current and parent directory
 config <- config::get()
 
+# Year-sensitive refresh parameters (GCS snapshot) — tracked in config_year.yml
+year_config <- config::get(file = "config_year.yml")
+
 # see https://catalogue.data.gov.bc.ca/dataset/bc-wildfire-fire-perimeters-historical
 # Load wildfire, DA spatial and cencus income data
 
@@ -118,7 +121,7 @@ tryCatch(
 
 income <- dbGetQuery(
   con,
-  statement = "
+  statement = sprintf("
 with geo as
 (
 SELECT distinct
@@ -127,7 +130,7 @@ SELECT distinct
       ,[CMACA_2021]
       ,[DA_2021]
       ,concat('59',[CD_2021],[DA_2021]) as ALT_DA
-  FROM [Population_Labour_Social].[Prod].[FCT_GCS_202509]
+  FROM [Population_Labour_Social].[%s].[%s]
   ),
   income as
   (
@@ -153,7 +156,7 @@ select [MUN_NAME_2021]
       popltn*popltn_sqr_km*1000 as sqr_m
 from income left join geo on [ALT_GEO_CODE]=ALT_DA
 order by [ALT_GEO_CODE]
-"
+", year_config$gcs$schema, year_config$gcs$table)
 )
 
 HECTARES_TO_SQM <- 1000000


### PR DESCRIPTION
06b_output_wildfire.R hardcoded the GCS snapshot FCT_GCS_202509 in its income query, bypassing config_year.yml (FCT_GCS_202606) that scripts 03/04 use — wildfire geography was resolved against an older snapshot than the rest of the pipeline.

- Add year_config <- config::get(file = "config_year.yml").
- Drive the query's GCS table via sprintf(...) from year_config$gcs (same pattern as 03/04).
- R parse clean (37 expressions).

DATA IMPACT: 06b now resolves against FCT_GCS_202606 (was 202509) — wildfire outputs will change. Re-run 06b in the secure environment after merge and verify/regenerate downstream wildfire outputs.