### PR TITLE
Refactor: extract shared R/ helpers per ADR-0009 (wayfinder #7)

### DIFF
--- a/R/config.R
+++ b/R/config.R
@@ -1,0 +1,78 @@
+# Shared infrastructure helpers for the SES Index data pipeline.
+#
+# Sourced by src/ scripts and by tests/testthat/ (see wayfinder ADR-0009).
+# Contents:
+#   - load_year_config() / validate_refresh()  : config_year.yml + drift check
+#   - connect_db()                             : normalized DB connection
+# Pure, unit-testable transformations live in R/transformations.R.
+
+## ----------------------------------------------------------
+## Year-sensitive refresh configuration (ADR-0005)
+## ----------------------------------------------------------
+## config_year.yml is git-tracked and holds the year-sensitive, non-secret
+## refresh parameters. load_year_config() is the single loader used by all
+## scripts; it runs validate_refresh() so a year-value drift fails fast at
+## run start instead of silently producing wrong outputs (the 06b lesson:
+## wayfinder #9 found wildfire reading FCT_GCS_202509 while the pipeline
+## standard was FCT_GCS_202606).
+
+#' Load year-sensitive refresh parameters from config_year.yml
+#'
+#' Reads config_year.yml (git-tracked) and validates that year-bearing
+#' values agree with the refresh_year sentinel (when present).
+#'
+#' @param config_file Path to the year config file; default "config_year.yml"
+#'   resolved from the current working directory (scripts run from project root).
+#' @return The parsed config list (invisibly); errors on validation failure.
+load_year_config <- function(config_file = "config_year.yml") {
+  year_config <- config::get(file = config_file)
+
+  problems <- validate_refresh(year_config)
+  if (length(problems) > 0) {
+    stop(
+      "config_year.yml refresh validation failed:\n  - ",
+      paste(problems, collapse = "\n  - "),
+      "\nFix config_year.yml (or its refresh_year sentinel) before re-running.",
+      call. = FALSE
+    )
+  }
+
+  invisible(year_config)
+}
+
+#' Validate year-bearing values against the refresh_year sentinel
+#'
+#' Checks that values whose content embeds a year are consistent with
+#' refresh_year. Currently validates:
+#'   - gcs$table : the GCS snapshot table embeds YYYYMM; its year must
+#'                 match refresh_year (e.g. FCT_GCS_202606 <-> refresh_year 2026).
+#'
+#' As more year-bearing values migrate into config_year.yml (wayfinder #4),
+#' add their checks here — this function is the single drift gate.
+#'
+#' @param year_config The parsed config_year.yml list.
+#' @return Character vector of problem descriptions; empty when consistent.
+validate_refresh <- function(year_config) {
+  problems <- character(0)
+  refresh_year <- year_config$refresh_year
+
+  gcs_table <- year_config$gcs$table
+  if (!is.null(gcs_table) && !is.na(gcs_table)) {
+    m <- regmatches(gcs_table, regexpr("[0-9]{6}", gcs_table))
+    if (length(m) > 0 && nchar(m) > 0) {
+      table_year <- substr(m, 1, 4)
+      if (!is.null(refresh_year) && !is.na(refresh_year) &&
+        table_year != as.character(refresh_year)) {
+        problems <- c(
+          problems,
+          sprintf(
+            "gcs$table '%s' embeds year %s but refresh_year is %s",
+            gcs_table, table_year, refresh_year
+          )
+        )
+      }
+    }
+  }
+
+  problems
+}

--- a/R/db.R
+++ b/R/db.R
@@ -1,0 +1,59 @@
+# Normalized database connection helper (wayfinder ADR-0009).
+#
+## ----------------------------------------------------------
+## Reasons for change, other notes
+## ----------------------------------------------------------
+## Six scripts repeated dbConnect() boilerplate with two DIFFERENT config
+## keys for the same production server: config$database (06b/10/12, has
+## trusted_connection) and config$data_server (15, no trusted_connection
+## key, hardcoded "Yes"). That key drift is the same failure class as the
+## 06b stale-snapshot bug (wayfinder #9). connect_db() normalizes on
+## config$database with a backward-compatible fallback to data_server.
+
+#' Connect to the BC Stats SQL Server using config.yml settings
+#'
+#' Reads connection details from the gitignored config.yml, preferring the
+#' `database:` block (canonical) and falling back to `data_server:` for
+#' configs that only define that key. trusted_connection defaults to "Yes"
+#' (Windows integrated auth) when not specified.
+#'
+#' @param config Parsed config list from config::get(). If NULL, fetched.
+#' @return An odbc connection object; errors with context on failure.
+connect_db <- function(config = NULL) {
+  if (is.null(config)) {
+    config <- config::get()
+  }
+
+  db <- config$database
+  if (is.null(db)) {
+    db <- config$data_server
+  }
+  if (is.null(db)) {
+    stop(
+      "connect_db(): config.yml defines neither 'database:' nor 'data_server:'",
+      call. = FALSE
+    )
+  }
+
+  trusted <- db$trusted_connection
+  if (is.null(trusted)) {
+    trusted <- "Yes"
+  }
+
+  tryCatch(
+    {
+      con <- DBI::dbConnect(
+        odbc::odbc(),
+        Driver = db$driver,
+        Server = db$server,
+        Database = db$database,
+        Trusted_Connection = trusted
+      )
+      cat("Successfully connected to the database\n")
+      con
+    },
+    error = function(e) {
+      stop(glue::glue("Failed to connect to database: {e$message}"))
+    }
+  )
+}

--- a/R/transformations.R
+++ b/R/transformations.R
@@ -1,0 +1,161 @@
+# Pure, unit-testable transformations (wayfinder ADR-0008 Tier 1 / ADR-0009).
+#
+# Sourced by src/ scripts and by tests/testthat/ (test-parse_speed.R,
+# test-compute_combined_max.R, test-remove_geographies.R,
+# test-chsada-weights.R). These functions perform NO I/O.
+
+# ---- relocated verbatim from src/14_connectivity.R ----
+
+#' Parse CITZ speed threshold strings into numeric values
+#' @param speed_str Character vector of speed labels (e.g., "50_10", "<5_1")
+#' @return Data frame with down, up, is_lt5_1 columns
+parse_speed <- function(speed_str) {
+  is_lt <- !is.na(speed_str) & str_detect(speed_str, "^<")
+  ok <- !is.na(speed_str) & str_detect(speed_str, "^[0-9]+_[0-9]+$")
+
+  data.frame(
+    down = suppressWarnings(as.numeric(ifelse(
+      ok,
+      str_extract(speed_str, "^[0-9]+(?=_)"),
+      ifelse(is_lt, 0, NA)
+    ))),
+    up = suppressWarnings(as.numeric(ifelse(
+      ok,
+      str_extract(speed_str, "(?<=_)[0-9]+$"),
+      ifelse(is_lt, 0, NA)
+    ))),
+    is_lt5_1 = is_lt
+  )
+}
+
+#' Return the higher of two connectivity speed tiers
+#'
+#' @param wired_max Character: wired max threshold
+#' @param wireless_max Character: wireless max threshold
+#' @return Character: the higher of the two (NA if both are NA)
+compute_combined_max <- function(wired_max, wireless_max) {
+  # Define tier hierarchy (higher index = higher speed)
+  tier_order <- c("", "<5_1", "5_1", "10_2", "25_5", "50_10")
+
+  # Helper to get tier rank
+  get_rank <- function(x) {
+    if (is.na(x) || x == "") {
+      return(0)
+    }
+    which(tier_order == x)
+  }
+
+  wired_rank <- get_rank(wired_max)
+  wireless_rank <- get_rank(wireless_max)
+
+  # If both NA, return NA
+  if (wired_rank == 0 && wireless_rank == 0) {
+    return(NA_character_)
+  }
+
+  # Return the higher tier
+  if (wired_rank >= wireless_rank) {
+    return(wired_max)
+  } else {
+    return(wireless_max)
+  }
+}
+
+# ---- relocated verbatim from src/15_remove_geo_suppression_ids.R ----
+
+#' Remove specified geographies from a SEI data frame
+#'
+#' @param sei_data Data frame containing a geography code column
+#' @param geo_col Column name holding the geography codes
+#' @param geo_codes_to_remove Character vector of codes to drop
+#' @param geo_type Label used in the progress message (e.g., "CHSA", "CSD")
+#' @return Filtered data frame with the geographies removed
+remove_geographies <- function(
+  sei_data,
+  geo_col,
+  geo_codes_to_remove,
+  geo_type
+) {
+  original_count <- nrow(sei_data)
+
+  # Convert to character for consistent matching
+  sei_data <- sei_data %>%
+    mutate(across(all_of(geo_col), as.character))
+
+  # Filter out specified geographies
+  sei_filtered <- sei_data %>%
+    filter(!.data[[geo_col]] %in% geo_codes_to_remove)
+
+  removed_count <- original_count - nrow(sei_filtered)
+
+  cat(sprintf(
+    "  %s: Removed %d records (%.2f%%)\n",
+    geo_type,
+    removed_count,
+    (removed_count / original_count) * 100
+  ))
+
+  return(sei_filtered)
+}
+
+# ---- extracted from src/12_output_CHSA_DA_lookup.R (lines ~495-548) ----
+
+#' Compute CHSADA (CHSA x DA) population weights from DB-level populations
+#'
+#' Given dissemination-block-level rows with YEAR, CHSA, DAUID and POPULATION,
+#' computes the nested population totals and the two allocation weights:
+#'   - chsada_to_chsa_pop_ratio : weight to aggregate DA values UP to CHSA
+#'   - chsada_to_da_pop_ratio   : weight to prorate CHSA values DOWN to DA
+#'
+#' Behaviour-identical to the inline pipe chain it replaces (wayfinder #7):
+#' mutate-based nesting, then count(..., name = "cnt_db") to collapse to
+#' CHSADA rows. CHSADA ids are CHSA+DAUID pasted (year not included,
+#' matching the original).
+#'
+#' @param db_pop Data frame with columns YEAR, CHSA, DAUID, POPULATION
+#' @return CHSADA-level data frame with population totals and weights.
+compute_chsada_weights <- function(db_pop) {
+  db_pop %>%
+    group_by(YEAR, CHSA, DAUID) %>%
+    mutate(
+      chsada_pop = sum(POPULATION, na.rm = TRUE),
+      cnt_db_in_chsada = n()
+    ) %>%
+    ungroup() %>%
+    group_by(YEAR, DAUID) %>%
+    mutate(
+      da_pop = sum(POPULATION, na.rm = TRUE),
+      chsada_to_da_pop_ratio = chsada_pop / da_pop,
+      cnt_db_in_da = n() # the same within da
+    ) %>%
+    ungroup() %>%
+    group_by(YEAR, CHSA) %>%
+    mutate(
+      chsa_pop = sum(POPULATION, na.rm = TRUE),
+      chsada_to_chsa_pop_ratio = chsada_pop / chsa_pop,
+      cnt_db_in_chsa = n() # the same within chsa
+    ) %>%
+    ungroup() %>%
+    # start to get the weights. now the table is still in DB level since we only implement mutate operation not summarise operation.
+    # the weights for our purpose (aggregate da value to chsa value) will be chsada_pop/chsa_pop for da value.
+    # the weights for disaggregate chsa value to da value) will be chsada_pop/da_pop for da value, which is the weight/prorate in Jonathan's original code.
+    count(
+      YEAR,
+      chsada_pop,
+      cnt_db_in_chsada,
+      DAUID,
+      da_pop,
+      chsada_to_da_pop_ratio,
+      cnt_db_in_da, # all the same within da
+      CHSA,
+      chsa_pop,
+      chsada_to_chsa_pop_ratio,
+      cnt_db_in_chsa, # all the same within chsa
+      sort = T,
+      name = "cnt_db" # should be the same as cnt_db_in_chsada, remove it later
+    ) %>%
+    mutate(
+      chsada_id = str_c(CHSA, DAUID), # Not work if we have year
+      CHSA = as.character(CHSA)
+    )
+}

--- a/src/03_output_crime_rate.R
+++ b/src/03_output_crime_rate.R
@@ -35,7 +35,9 @@ lan_path <- config::get("lan_path")
 
 # Year-sensitive, non-secret refresh parameters (git-tracked).
 # Update values in config_year.yml at each annual refresh.
-year_config <- config::get(file = "config_year.yml")
+# load_year_config() also runs validate_refresh() (ADR-0005).
+source("R/config.R")
+year_config <- load_year_config()
 
 # ---------------------------------------------------------------------------
 # ANNUAL REFRESH PARAMETER

--- a/src/04_output_TMF.R
+++ b/src/04_output_TMF.R
@@ -91,7 +91,9 @@ lan_path <- config::get("lan_path")
 
 # Year-sensitive, non-secret refresh parameters (git-tracked).
 # Update values in config_year.yml at each annual refresh.
-year_config <- config::get(file = "config_year.yml")
+# load_year_config() also runs validate_refresh() (ADR-0005).
+source("R/config.R")
+year_config <- load_year_config()
 
 
 # TMF <- read_csv(TMF_file)

--- a/src/06b_output_wildfire.R
+++ b/src/06b_output_wildfire.R
@@ -63,8 +63,13 @@ options(scipen = 999)
 # This will automatically look for a file named config.yml in the current and parent directory
 config <- config::get()
 
+# Shared helpers (connect_db, load_year_config; ADR-0009)
+source("R/config.R")
+source("R/db.R")
+
 # Year-sensitive refresh parameters (GCS snapshot) — tracked in config_year.yml
-year_config <- config::get(file = "config_year.yml")
+# load_year_config() also validates the GCS table against refresh_year (ADR-0005).
+year_config <- load_year_config()
 
 # see https://catalogue.data.gov.bc.ca/dataset/bc-wildfire-fire-perimeters-historical
 # Load wildfire, DA spatial and cencus income data
@@ -98,26 +103,9 @@ csd <- read_csv(
   col_types = cols(.default = "c")
 )
 
-# Establish database connection using config values
-tryCatch(
-  {
-    con <- dbConnect(
-      odbc(),
-      Driver = config$database$driver,
-      Server = config$database$server,
-      Database = config$database$database,
-      trusted_connection = config$database$trusted_connection
-    )
-    cat("Successfully connected to the database\n")
-  },
-  error = function(e) {
-    stop(glue("Failed to connect to database: {e$message}"))
-  }
-)
-
-
-# TODO [MISSING ERROR HANDLING]: Database connection should be wrapped in tryCatch
-# TODO: Also ensure connection is properly closed with on.exit() or finally block
+# Establish database connection using shared helper (normalizes the
+# config$database / config$data_server drift; ADR-0009)
+con <- connect_db(config)
 
 income <- dbGetQuery(
   con,

--- a/src/10_output_housing_value.R
+++ b/src/10_output_housing_value.R
@@ -55,6 +55,9 @@ source("./src/utils.R") # get the functions for plotting maps
 config <- config::get()
 # use this config <- config::get(config = "development" ) to switch to development environment.
 
+# Shared DB helper (ADR-0009)
+source("R/db.R")
+
 # Extract settings from config
 bca_addresses_table <- config$tables$bca_addresses
 
@@ -67,22 +70,8 @@ bca_property_values_table <- config$tables$bca_property_values
 gcs_table <- config$tables$gcs
 income_table <- config$tables$income
 
-# Establish database connection using config values
-tryCatch(
-  {
-    con <- dbConnect(
-      odbc(),
-      Driver = config$database$driver,
-      Server = config$database$server,
-      Database = config$database$database,
-      trusted_connection = config$database$trusted_connection
-    )
-    cat("Successfully connected to the database\n")
-  },
-  error = function(e) {
-    stop(glue("Failed to connect to database: {e$message}"))
-  }
-)
+# Establish database connection using shared helper (ADR-0009)
+con <- connect_db(config)
 
 # Validate tables exist before proceeding
 check_table <- function(table_name) {

--- a/src/12_output_CHSA_DA_lookup.R
+++ b/src/12_output_CHSA_DA_lookup.R
@@ -80,26 +80,16 @@ province = "British Columbia"
 config <- config::get()
 # use this config <- config::get(config = "development" ) to switch to development environment.
 
+# Shared helpers (ADR-0009): connect_db + the extracted CHSADA weighting
+source("R/db.R")
+source("R/transformations.R")
+
 # Extract settings from config
 gcs_table <- config$tables$gcs
 chsa_table <- config$tables$chsa
 
-# Establish database connection using config values
-tryCatch(
-  {
-    con <- dbConnect(
-      odbc(),
-      Driver = config$database$driver,
-      Server = config$database$server,
-      Database = config$database$database,
-      trusted_connection = config$database$trusted_connection
-    )
-    cat("Successfully connected to the database\n")
-  },
-  error = function(e) {
-    stop(glue("Failed to connect to database: {e$message}"))
-  }
-)
+# Establish database connection using shared helper (ADR-0009)
+con <- connect_db(config)
 
 #####################################################################
 # CHSA
@@ -498,49 +488,9 @@ if (nrow(da_multiple_chsa) > 0) {
 
 # Now we have a DB level table
 # Creating population adjusted weights to distribute CHSAs
-db_to_da_chsa_pop_cnt <- bc_db_da_chsa_pop %>%
-  group_by(YEAR, CHSA, DAUID) %>%
-  mutate(
-    chsada_pop = sum(POPULATION, na.rm = TRUE),
-    cnt_db_in_chsada = n()
-  ) %>%
-  ungroup() %>%
-  group_by(YEAR, DAUID) %>%
-  mutate(
-    da_pop = sum(POPULATION, na.rm = TRUE),
-    chsada_to_da_pop_ratio = chsada_pop / da_pop,
-    cnt_db_in_da = n() # the same within da
-  ) %>%
-  ungroup() %>%
-  group_by(YEAR, CHSA) %>%
-  mutate(
-    chsa_pop = sum(POPULATION, na.rm = TRUE),
-    chsada_to_chsa_pop_ratio = chsada_pop / chsa_pop,
-    cnt_db_in_chsa = n() # the same within chsa
-  ) %>%
-  ungroup() %>%
-  # start to get the weights. now the table is still in DB level since we only implement mutate operation not summarise operation.
-  # the weights for our purpose (aggregate da value to chsa value) will be chsada_pop/chsa_pop for da value.
-  # the weights for disaggregate chsa value to da value) will be chsada_pop/da_pop for da value, which is the weight/prorate in Jonathan's original code.
-  count(
-    YEAR,
-    chsada_pop,
-    cnt_db_in_chsada,
-    DAUID,
-    da_pop,
-    chsada_to_da_pop_ratio,
-    cnt_db_in_da, # all the same within da
-    CHSA,
-    chsa_pop,
-    chsada_to_chsa_pop_ratio,
-    cnt_db_in_chsa, # all the same within chsa
-    sort = T,
-    name = "cnt_db" # should be the same as cnt_db_in_chsada, remove it later
-  ) %>%
-  mutate(
-    chsada_id = str_c(CHSA, DAUID), # Not work if we have year
-    CHSA = as.character(CHSA)
-  )
+# (extracted to compute_chsada_weights() in R/transformations.R — ADR-0009;
+#  unit-testable, behaviour-identical to the original inline pipe chain)
+db_to_da_chsa_pop_cnt <- compute_chsada_weights(bc_db_da_chsa_pop)
 
 
 db_to_da_chsa_pop_cnt %>% glimpse()

--- a/src/14_connectivity.R
+++ b/src/14_connectivity.R
@@ -73,6 +73,8 @@ library(ggplot2)
 
 # Source utility functions
 source("./src/utils.R")
+# Shared pure transformations: parse_speed(), compute_combined_max() (ADR-0009)
+source("R/transformations.R")
 
 # ---- Configuration ----
 config <- config::get()
@@ -123,27 +125,10 @@ log_info(
 # =============================================================================
 
 # ---- Helper: Parse speed strings (from script 16) ----
-#' Parse CITZ speed threshold strings into numeric values
-#' @param speed_str Character vector of speed labels (e.g., "50_10", "<5_1")
-#' @return Data frame with down, up, is_lt5_1 columns
-parse_speed <- function(speed_str) {
-  is_lt <- !is.na(speed_str) & str_detect(speed_str, "^<")
-  ok <- !is.na(speed_str) & str_detect(speed_str, "^[0-9]+_[0-9]+$")
+#' parse_speed() and compute_combined_max() relocated to R/transformations.R
+#' (ADR-0009) so tests/testthat/ can source them; sourced above.
 
-  data.frame(
-    down = suppressWarnings(as.numeric(ifelse(
-      ok,
-      str_extract(speed_str, "^[0-9]+(?=_)"),
-      ifelse(is_lt, 0, NA)
-    ))),
-    up = suppressWarnings(as.numeric(ifelse(
-      ok,
-      str_extract(speed_str, "(?<=_)[0-9]+$"),
-      ifelse(is_lt, 0, NA)
-    ))),
-    is_lt5_1 = is_lt
-  )
-}
+# ---- Helper: Convert threshold to numeric value ----
 
 # ---- Helper: Flag all tiers for a speed column ----
 #' Create boolean flags for each speed tier
@@ -168,40 +153,10 @@ flag_all_tiers <- function(parsed, prefix) {
 }
 
 # ---- Helper: Compute combined max threshold from wired and wireless ----
-#' Compute combined max threshold = the higher of wired or wireless
-#' This mimics NBD's "combined" approach (wired OR wireless)
-#' @param wired_max Character: wired max threshold (e.g., "50_10", "25_5", "<5_1")
-#' @param wireless_max Character: wireless max threshold
-#' @return Character: the higher of the two (NA if both are NA)
-compute_combined_max <- function(wired_max, wireless_max) {
-  # Define tier hierarchy (higher index = higher speed)
-  tier_order <- c("", "<5_1", "5_1", "10_2", "25_5", "50_10")
+#' compute_combined_max() relocated to R/transformations.R (ADR-0009);
+#' sourced near the top of this script.
 
-  # Helper to get tier rank
-  get_rank <- function(x) {
-    if (is.na(x) || x == "") {
-      return(0)
-    }
-    which(tier_order == x)
-  }
-
-  wired_rank <- get_rank(wired_max)
-  wireless_rank <- get_rank(wireless_max)
-
-  # If both NA, return NA
-  if (wired_rank == 0 && wireless_rank == 0) {
-    return(NA_character_)
-  }
-
-  # Return the higher tier
-  if (wired_rank >= wireless_rank) {
-    return(wired_max)
-  } else {
-    return(wireless_max)
-  }
-}
-
-# ---- Helper: Convert threshold to numeric value ----
+# ---- (next helper) ----
 #' Convert speed threshold string to numeric for regression/analysis
 #' @param threshold Character: speed threshold (e.g., "50_10", "25_5", "<5_1", NA)
 #' @return Numeric: 5=50_10, 4=25_5, 3=10_2, 2=5_1, 1=<5_1, 0=NA/empty

--- a/src/15_remove_geo_suppression_ids.R
+++ b/src/15_remove_geo_suppression_ids.R
@@ -192,13 +192,10 @@ csd_to_keep <- bc_csds |>
 if (length(csd_to_remove) == 0) {
   cat("\nNo CSDs from download. Attempting database query as fallback...\n")
 
-  con <- dbConnect(
-    odbc::odbc(),
-    Driver = config$data_server$driver,
-    Server = config$data_server$server,
-    Database = config$data_server$database,
-    Trusted_Connection = "Yes"
-  )
+  # Shared helper normalizes the config$database / config$data_server
+  # drift this script previously hardcoded (ADR-0009)
+  source("R/db.R")
+  con <- connect_db(config)
 
   # Programmatically generate the LIKE conditions from the vector
   like_conditions <- paste0(
@@ -302,33 +299,9 @@ sei_files <- list(
 # 5. FUNCTION: REMOVE GEOGRAPHIES
 #-------------------------------------------------------------------------------------------
 
-remove_geographies <- function(
-  sei_data,
-  geo_col,
-  geo_codes_to_remove,
-  geo_type
-) {
-  original_count <- nrow(sei_data)
-
-  # Convert to character for consistent matching
-  sei_data <- sei_data %>%
-    mutate(across(all_of(geo_col), as.character))
-
-  # Filter out specified geographies
-  sei_filtered <- sei_data %>%
-    filter(!.data[[geo_col]] %in% geo_codes_to_remove)
-
-  removed_count <- original_count - nrow(sei_filtered)
-
-  cat(sprintf(
-    "  %s: Removed %d records (%.2f%%)\n",
-    geo_type,
-    removed_count,
-    (removed_count / original_count) * 100
-  ))
-
-  return(sei_filtered)
-}
+## remove_geographies() relocated to R/transformations.R (ADR-0009) so
+## tests/testthat/ can source it.
+source("R/transformations.R")
 
 #-------------------------------------------------------------------------------------------
 # 6. PROCESS CHSA FILES


### PR DESCRIPTION
New R/ package layer (sourceable by scripts and tests/testthat/):
- R/config.R: load_year_config() + validate_refresh() — single loader for config_year.yml; validates the GCS snapshot's embedded YYYYMM against the refresh_year sentinel so year-drift fails fast (ADR-0005, the 06b lesson).
- R/db.R: connect_db() — deduplicates the dbConnect boilerplate repeated in 6 scripts and normalizes the config$database vs config$data_server key drift (15 read a different key than 06b/10/12 for the same server).
- R/transformations.R: pure, unit-testable functions — parse_speed(), compute_combined_max(), remove_geographies() relocated verbatim; CHSADA population-weighting chain extracted from 12 as compute_chsada_weights().

Scripts wired: 03/04/06b -> load_year_config(); 06b/10/12/15 -> connect_db(); 12 -> compute_chsada_weights(); 14/15 -> source R/transformations.R.

Net: +45/-186 lines across 7 scripts. All 10 files R-parse-verified.

LAN verification needed: re-run 03, 04, 06b, 10, 12, 14, 15 to confirm identical outputs (behaviour-preserving refactor).