### PR TITLE
Config migration: retire hardcoded values into config_year.yml (ADR-0…

### DIFF
--- a/config_year.yml
+++ b/config_year.yml
@@ -3,16 +3,148 @@ default:
   # Year-sensitive, NON-SECRET refresh parameters for the SES Index pipelines.
   # This file is tracked in git (unlike config.yml, which holds secrets).
   # Update the values below at each annual refresh.
+  #
+  # ANNUAL REFRESH CONTRACT (ADR-0005):
+  #   1. Bump refresh_year below.
+  #   2. Update gcs$table so its embedded YYYYMM matches refresh_year — this
+  #      pair is the ONLY automated check (validate_refresh() in R/config.R).
+  #   3. Review every value tagged [year-bearing] at each refresh and update
+  #      as needed (end-years of ranges, release-vintage URLs, output_year).
+  #      NOTE: some legitimately lag refresh_year — e.g. project_folder says
+  #      "2024 SES Index" because the data cycle is 2024 while the work year
+  #      is 2026 (ADR-0001: data year vs work year). Review, don't assume.
+  #   4. Run the pipeline. Nothing else should need editing.
   # ---------------------------------------------------------------------------
+
+  # [year-bearing] The refresh this config is set up for. Every year-bearing
+  # value below must agree with this year (checked by validate_refresh()).
+  refresh_year: 2026
 
   # GCS (Translation Master File) snapshot used to resolve DA -> RESP.
   # Update `table` each refresh to the current GCS snapshot table name.
+  # [year-bearing] embedded YYYYMM must match refresh_year.
   gcs:
     schema: "prod"
     table: "FCT_GCS_202606"
 
-  # Local cansim sqlite cache directory. Referenced every run; not year-sensitive
-  # but centralized here so the cache path is not repeated as a literal in scripts.
+  # Local caches. [stable] Referenced every run; not year-sensitive but
+  # centralized here so the path is not repeated as a literal in scripts.
+  # NOTE (wayfinder #8): machine-specific; candidates to move to .Renviron.
   cansim_cache_path: "C:/Temp/cansim_cache"
   cancensus_cache_path: "C:/Temp/census_cache"
 
+  # --------------------------------------------------------------------------
+  # Year windows (audit category A)
+  # --------------------------------------------------------------------------
+
+  # [year-bearing] end year; start year is stable.
+  crime:
+    start_year: 2000
+
+  wildfire:
+    min_fire_year: 2000          # [stable]
+    historic_end_year: 2024      # [year-bearing] current/data split boundary
+    summary_year_range: [2011, 2025]  # [year-bearing] final report range
+    test_year_range: [2016, 2025]     # [year-bearing] exploratory check range
+
+  population_estimates:
+    year_range: [2000, 2024]     # [year-bearing] end year
+
+  chsa_lookup:
+    range_2021_census: [2019, 2023]  # [year-bearing] 2021-census-era crosswalk
+    range_2016_census: [2016, 2018]  # [year-bearing] 2016-census-era crosswalk
+    range_db_pop: [2016, 2023]       # [year-bearing] DB population / CHSA lookup
+
+  # [year-bearing] year stamped on BC Data Catalogue output products (script 15).
+  output_year: 2023
+
+  # [stable] census vintage for geographic attributes (moves only when a new
+  # census drops — then update everywhere, not annually).
+  census_vintage: "2021"
+
+  # --------------------------------------------------------------------------
+  # LAN file paths, relative to the lan_path root (audit category C)
+  # --------------------------------------------------------------------------
+
+  # [year-bearing] folder name embeds the data-cycle year.
+  project_folder: "2024 SES Index"
+
+  # 03 — crime rate
+  crime_da_resp_lookup: "data/raw_data/crime_rate/Pop by DA and RESP.xlsx"
+  crime_dict_output: "data/output/Crime_Rate_Dict_DIP.csv"
+
+  # 04 — TMF
+  tmf_data_dict: "docs/TMF_data_dict.csv"
+  tmf_lookup_table: "data/raw_data/TMF/GCS_Lookup_Table.xlsx"
+
+  # 05 — LFS / SLA
+  sla_file: "data/StatsCanLFS/SLA2016_FinalClassification.xlsx"
+
+  # 06a/06b/09 — DA boundary shapefile (shared)
+  da_boundary_shp: "data/other/StatsCAN_sgc/lda_000a21a_e/lda_000b21a_e.shp"
+
+  # 09 — remoteness inputs/outputs
+  remoteness:
+    csd_boundary_shp: "data/raw_data/remoteness/lcsd000b21a_e/lcsd000b21a_e.shp"
+    servicebc_geocoded: "data/raw_data/remoteness/30_percent_site_Hybrid_geocoder_DA_nearest_servicebc_20250212_150617.zik"
+    hospital_geocoded: "data/raw_data/remoteness/30_percent_site_Hybrid_geocoder_DA_nearest_hospitals_20250219_100047.zik"
+    school_geocoded: "data/raw_data/remoteness/30_percent_site_Hybrid_geocoder_DA_nearest_schools_20250222_180651.zik"
+    proximity_analysis: "data/raw_data/remoteness/proximity_analysis_route_salvaging"
+    address_with_da_csv: "data/raw_data/remoteness/bc_address_with_da.csv"
+    avg_dist_drvtime_csv: "data/output/remoteness/avg_dist_drvtime_by_da_facility.csv"
+    csd_remoteness_csv: "data/output/remoteness/CSD_REMOTENESS_BY_FACILITY.csv"
+
+  # 11 — CISV/CISR/CIMD
+  cisr_cisv_folder: "data/raw_data/StatsCAN_CISR_CISV_CIMD/CISR_CISV/"
+  cimd_folder: "data/raw_data/StatsCAN_CISR_CISV_CIMD/CIMD/"
+
+  # 12 — CHSA-DA crosswalk
+  chsa_da_crosswalk_folder: "data/raw_data/chsa_da_crosswalk/"
+
+  # 14 — connectivity (CITZ micro-data folder)
+  citz_folder: "data/raw_data/internet_connectivity/CITZ"
+
+  # 15 — BC Data Catalogue output folder (relative to project_folder)
+  data_catalogue_folder: "bc data catalogue/Data Catalogue final products"
+
+  # 17 — PowerBI geo layers
+  chsa_geojson: "data/other/StatsCAN_sgc/chsa_2022_wgs.json"
+  lower_mainland_chsa_json: "data/other/StatsCAN_sgc/lower_mainland_chsa.json"
+  sgc_structure_csv: "data/other/StatsCAN_sgc/sgc_structure_csd_BC.csv"
+
+  # 17/18 — index exports (delivery inputs)
+  index_exports_path: "exports/2025-07-31-initial-index-results"
+
+  # 18 — trend maps
+  csd_boundary_2021_shp: "2021 Census Boundary Files - 2023 Release/csd_2021.shp"
+
+  # --------------------------------------------------------------------------
+  # Download URLs (audit category D) — [year-bearing] where the release
+  # vintage embeds a year; update when StatsCan publishes a new release.
+  # --------------------------------------------------------------------------
+
+  dguid_url: "https://www12.statcan.gc.ca/census-recensement/2021/geo/sip-pis/dguid-idugd/files-fichiers/2021_98260004.zip"
+  sgc_structure_url: "https://www.statcan.gc.ca/en/statistical-programs/document/sgc-cgt-2021-structure-eng.csv"
+  da_boundary_url: "https://www12.statcan.gc.ca/census-recensement/2021/geo/sip-pis/boundary-limites/files-fichiers/lda_000b21a_e.zip"
+  cisr_url: "https://www150.statcan.gc.ca/pub/45-20-0001/2025001/csv/cisr-eng.zip"
+  cisv_url: "https://www150.statcan.gc.ca/pub/45-20-0001/2025001/csv/cisv-eng.zip"
+  cimd_url: "https://www150.statcan.gc.ca/pub/45-20-0001/2023001/csv/bc_scores_quintiles_csv-eng.zip.zip"
+
+  # --------------------------------------------------------------------------
+  # BC Data Catalogue record IDs (audit category E) — [stable] unless a
+  # dataset is republished under a new record.
+  # --------------------------------------------------------------------------
+
+  bcdc:
+    chha_record_id: "68f2f577-28a7-46b4-bca9-7e9770f2f357"
+    population_record_id: "86839277-986a-4a29-9f70-fa9b1166f6cb"
+    wildfire_historic_record_id: "22c7cb44-1463-48f7-8e47-88857f207702"
+    wildfire_current_record_id: "cdfc2d7b-c046-4bf0-90ac-4897232619e1"
+    population_resource_id: "0e15d04d-127c-457a-b999-20800c929927"
+
+  # --------------------------------------------------------------------------
+  # Disclosure-control codes (audit category F) — [stable]; review annually
+  # against StatsCan CSD type documentation (see src/README.md).
+  # --------------------------------------------------------------------------
+
+  indig_csd_types: ["IRI", "IGD", "NL", "S-É", "TAL", "TWL"]

--- a/src/03_output_crime_rate.R
+++ b/src/03_output_crime_rate.R
@@ -339,7 +339,7 @@ crime_rate_dict <- create_dictionary(
 write_csv2(crime_rate_dict, here::here("out/Crime_Rate_Dict_DIP.csv"))
 write.csv2(
   crime_rate_dict,
-  use_network_path("2024 SES Index/data/output/Crime_Rate_Dict_DIP.csv")
+  use_network_path(file.path(year_config$project_folder, year_config$crime_dict_output))
 )
 
 log_info("Wrote crime rate data dictionary to DIP and LAN")

--- a/src/05_output_LFS.R
+++ b/src/05_output_LFS.R
@@ -40,6 +40,13 @@ log_info <- function(msg) {
   print(paste(Sys.time(), "|", msg))
 }
 
+# Load configs (ADR-0005). NOTE: lan_path previously leaked from another
+# script's session; this script now loads its own.
+config <- config::get()
+source("R/config.R")
+year_config <- load_year_config()
+lan_path <- config$lan_path
+
 # Load LFS data from StatsCan
 cansim_id <- "14-10-0457-01"
 log_info(glue::glue("Loading LFS data from StatsCan table {cansim_id}..."))
@@ -120,7 +127,7 @@ print(LFS)
 
 # Load SLA geography linkage file
 SLA_file <- glue::glue(
-  "{lan_path}/2024 SES Index/data/StatsCanLFS/SLA2016_FinalClassification.xlsx"
+  "{lan_path}/{year_config$project_folder}/{year_config$sla_file}"
 )
 log_info(glue::glue("Loading SLA linkage file from: {SLA_file}"))
 SLA_raw <- readxl::read_excel(SLA_file)

--- a/src/06a_output_wildfire.R
+++ b/src/06a_output_wildfire.R
@@ -47,17 +47,24 @@ pacman::p_load(
 ## Turn off spherical geometry
 sf::sf_use_s2(FALSE)
 
+# Load configs (ADR-0005). NOTE: this script previously relied on lan_path
+# leaking from another script's session — now loads its own.
+config <- config::get()
+source("R/config.R")
+year_config <- load_year_config()
+lan_path <- config$lan_path
+
 ###################################################################
 # BC Wildfire Fire Perimeters - Historical
 # https://catalogue.data.gov.bc.ca/dataset/22c7cb44-1463-48f7-8e47-88857f207702
 ###################################################################
 
 ## READ HISTORICAL WILDFIRES
-bcdc_get_record("22c7cb44-1463-48f7-8e47-88857f207702")
+bcdc_get_record(year_config$bcdc$wildfire_historic_record_id)
 
 # Access the full 'Resources' data frame using:
-bcdc_tidy_resources('22c7cb44-1463-48f7-8e47-88857f207702')
-MIN_FIRE_YEAR <- 2000
+bcdc_tidy_resources(year_config$bcdc$wildfire_historic_record_id)
+MIN_FIRE_YEAR <- year_config$wildfire$min_fire_year
 # Query and filter data using:
 BC_wildfire_perimeter_historic <- bcdc_query_geodata(
   '22c7cb44-1463-48f7-8e47-88857f207702'
@@ -183,12 +190,12 @@ bcdc_get_record("cdfc2d7b-c046-4bf0-90ac-4897232619e1")
 # Available Resources (1):
 # 1. View WMS getCapabilities request details (wms)
 # Access the full 'Resources' data frame using:
-bcdc_tidy_resources('cdfc2d7b-c046-4bf0-90ac-4897232619e1')
+bcdc_tidy_resources(year_config$bcdc$wildfire_current_record_id)
 # Query and filter data
 BC_wildfire_perimeter_current <- bcdc_query_geodata(
-  'cdfc2d7b-c046-4bf0-90ac-4897232619e1'
+  year_config$bcdc$wildfire_current_record_id
 ) %>%
-  filter(FIRE_YEAR >= 2024) %>% # The data in BC data has one row FIRE_NUMBER == 'G51564' for 2023 which is duplicated since it is in historic dataset.
+  filter(FIRE_YEAR >= year_config$wildfire$historic_end_year) %>% # The data in BC data has one row FIRE_NUMBER == 'G51564' for 2023 which is duplicated since it is in historic dataset.
   collect() %>%
   mutate(FIRE_LABEL = paste(FIRE_YEAR, FIRE_NUMBER, sep = '-'))
 
@@ -271,14 +278,14 @@ BC_wildfire_perimeter %>% # Save to a new file (optional)
 # ## READ DISSEMINATION DAs
 file_path <- file.path(
   lan_path,
-  "2024 SES Index/data/other/StatsCAN_sgc/lda_000a21a_e/lda_000b21a_e.shp"
+  file.path(year_config$project_folder, year_config$da_boundary_shp)
 )
 
 
 if (!file.exists(file_path)) {
   # grab the file from "Statistics Canada", only run once.
   download.file(
-    "https://www12.statcan.gc.ca/census-recensement/2021/geo/sip-pis/boundary-limites/files-fichiers/lda_000b21a_e.zip",
+    year_config$da_boundary_url,
     destfile = use_network_path(
       "data/other/StatsCAN_sgc/lda_000a21a_e/lda_000a21a_e.zip"
     )

--- a/src/06b_output_wildfire.R
+++ b/src/06b_output_wildfire.R
@@ -91,7 +91,7 @@ wildfires |>
 das <- sf::st_read(
   file.path(
     lan_path,
-    "2024 SES Index/data/other/StatsCAN_sgc/lda_000a21a_e/lda_000b21a_e.shp"
+    file.path(year_config$project_folder, year_config$da_boundary_shp)
   )
 )
 da_to_csd <- read_csv(
@@ -198,7 +198,7 @@ intersection_concise <- intersection %>%
   arrange(desc(pcnt_fire_2))
 
 #--------test distinct DAUID by year---------------------
-YEAR_RANGE <- 2016:2025
+YEAR_RANGE <- year_config$wildfire$test_year_range[1]:year_config$wildfire$test_year_range[2]
 intersection_concise %>%
   filter(substr(DAUID, 1, 2) == "59", FIRE_YEAR %in% YEAR_RANGE) %>%
   group_by(FIRE_YEAR) %>%
@@ -207,7 +207,7 @@ intersection_concise %>%
   )
 
 intersection_concise |> count(FIRE_YEAR)
-YEAR_RANGE <- 2011:2025
+YEAR_RANGE <- year_config$wildfire$summary_year_range[1]:year_config$wildfire$summary_year_range[2]
 #--------final report by year---------------------
 intersection_byyear <- intersection_concise %>%
   filter(

--- a/src/08_BC_population_estimates.R
+++ b/src/08_BC_population_estimates.R
@@ -14,11 +14,15 @@
 # The data is downloaded in CSV format and saved to the out folder
 # updated: 2025-02-20 we need the age groups, so redo this step
 
-pacman::p_load(tidyverse, readxl, safepaths,bcdata)
+pacman::p_load(tidyverse, readxl, safepaths, bcdata, config)
 library(dplyr)
 library(tidyr)
 library(janitor)
 library(datadictionary)
+
+# Year-sensitive refresh parameters (record IDs, year range) — ADR-0005
+source("R/config.R")
+year_config <- load_year_config()
 
 # only need to run once to find the right record id in data catalogue.
 # bcdc_search("municipality-population")
@@ -26,12 +30,16 @@ library(datadictionary)
 # bcdc_browse("86839277-986a-4a29-9f70-fa9b1166f6cb")
 
 
-bc_sub_provincial_population_estimates_and_projections <- bcdc_get_record("86839277-986a-4a29-9f70-fa9b1166f6cb")
+bc_sub_provincial_population_estimates_and_projections <- bcdc_get_record(
+  year_config$bcdc$population_record_id
+)
 
-bcdc_tidy_resources('86839277-986a-4a29-9f70-fa9b1166f6cb')
-# 7 Regional Districts (Census Divisions) is what we need. 
-municipality_population_df <- bcdc_get_data('86839277-986a-4a29-9f70-fa9b1166f6cb', 
-                                            resource = '0e15d04d-127c-457a-b999-20800c929927')
+bcdc_tidy_resources(year_config$bcdc$population_record_id)
+# 7 Regional Districts (Census Divisions) is what we need.
+municipality_population_df <- bcdc_get_data(
+  year_config$bcdc$population_record_id,
+  resource = year_config$bcdc$population_resource_id
+)
 
 # check the length of the regions
 municipality_population_df %>%
@@ -85,9 +93,10 @@ TMF_CSD <- TMF %>%
   rename(COUNT_POSTAL_CODE = n)
   
 
-# Transform TMF_CSD data frame to include a continuous YEAR column ranging from 2000 to 2024, and to fill in missing values appropriately,
+# Transform TMF_CSD data frame to include a continuous YEAR column from the
+# configured population-estimates range, filling missing values appropriately.
 
-years <- 2000:2024
+years <- year_config$population_estimates$year_range[1]:year_config$population_estimates$year_range[2]
 
 complete_data <- TMF_CSD %>%
   distinct( CDCSD, CSD, MUNNAME) %>%

--- a/src/09_output_remoteness.R
+++ b/src/09_output_remoteness.R
@@ -55,6 +55,10 @@ library(patchwork)
 # Load the rlang package for the bang-bang operator
 library(rlang)
 source("./src/utils.R") # get the functions for plotting maps
+
+# Year-sensitive refresh parameters (URLs, shapefile/geocoded paths) — ADR-0005
+source("R/config.R")
+year_config <- load_year_config()
 ###################################################################
 # # boundary files
 # https://www12.statcan.gc.ca/census-recensement/2021/geo/sip-pis/boundary-limites/index2021-eng.cfm?year=21
@@ -73,7 +77,7 @@ options(timeout = 600)
 ###########################################################################################
 # get the Dissemination Geographies Relationship File from statscan
 ###########################################################################################
-geouid_url = "https://www12.statcan.gc.ca/census-recensement/2021/geo/sip-pis/dguid-idugd/files-fichiers/2021_98260004.zip"
+geouid_url = year_config$dguid_url
 
 download.file(geouid_url, destfile = "./out/2021_98260004.zip")
 
@@ -101,7 +105,7 @@ bc_csd_daid_df <- bc_daid_df %>%
 ###########################################################################################
 
 # get the csd file from statscan
-SGC_2021_url = "https://www.statcan.gc.ca/en/statistical-programs/document/sgc-cgt-2021-structure-eng.csv"
+SGC_2021_url = year_config$sgc_structure_url
 
 download.file(SGC_2021_url, destfile = "./out/sgc-cgt-2021-structure-eng.csv")
 
@@ -147,7 +151,7 @@ bc_csdid_name_daid_2021_df %>%
 #       exdir = use_network_path("2024 SES Index/data/raw_data/remoteness/lda_000a21a_e"))
 # ## READ DISSEMINATION BLOCKS
 file_path <- use_network_path(
-  "2024 SES Index/data/raw_data/remoteness/lda_000a21a_e/lda_000b21a_e.shp"
+  file.path(year_config$project_folder, year_config$da_boundary_shp)
 )
 #
 # # Load the dissemination area shapefile
@@ -168,7 +172,7 @@ da_shapefile <- da_shapefile %>%
 # unzip(use_network_path("2024 SES Index/data/raw_data/remoteness/lcsd000b21a_e.zip"),
 #       exdir = use_network_path("2024 SES Index/data/raw_data/remoteness/"))
 file_path <- use_network_path(
-  "2024 SES Index/data/raw_data/remoteness/lcsd000b21a_e/lcsd000b21a_e.shp"
+  file.path(year_config$project_folder, year_config$remoteness$csd_boundary_shp)
 )
 # Load the dissemination area shapefile
 csd_shapefile <- st_read(file_path)
@@ -199,7 +203,7 @@ csd_shapefile %>%
 # we are going to use this one.
 # zik files are just zip files, so read_csv can handle them directly.
 new_da_servicebc_file_path_2 = use_network_path(
-  "2024 SES Index/data/raw_data/remoteness/30_percent_site_Hybrid_geocoder_DA_nearest_servicebc_20250212_150617.zik"
+  file.path(year_config$project_folder, year_config$remoteness$servicebc_geocoded)
 )
 new_da_servicebc_df2 <- read_csv(new_da_servicebc_file_path_2)
 new_da_servicebc_df2 %>% glimpse()
@@ -210,7 +214,7 @@ new_da_servicebc_df2 %>%
 # 2,715 ??
 # new data for hospital
 new_da_hospital_file_path = use_network_path(
-  "2024 SES Index/data/raw_data/remoteness/30_percent_site_Hybrid_geocoder_DA_nearest_hospitals_20250219_100047.zik"
+  file.path(year_config$project_folder, year_config$remoteness$hospital_geocoded)
 )
 
 new_da_hospital_df <- read_csv(new_da_hospital_file_path)
@@ -219,7 +223,7 @@ new_da_hospital_df %>% glimpse()
 
 # new data for school
 new_da_school_file_path = use_network_path(
-  "2024 SES Index/data/raw_data/remoteness/30_percent_site_Hybrid_geocoder_DA_nearest_schools_20250222_180651.zik"
+  file.path(year_config$project_folder, year_config$remoteness$school_geocoded)
 )
 
 new_da_school_df <- read_csv(new_da_school_file_path)
@@ -240,7 +244,7 @@ new_da_school_df %>%
 # geodata team fixed them.
 # replacement of those addresses that missed coordinates or are not connected to road network
 replacement_file_path = use_network_path(
-  "2024 SES Index/data/raw_data/remoteness/proximity_analysis_route_salvaging"
+  file.path(year_config$project_folder, year_config$remoteness$proximity_analysis)
 )
 replacement_files <- list.files(
   replacement_file_path,
@@ -282,7 +286,7 @@ address_sf_with_da <- address_sf_with_da %>%
 address_sf_with_da %>%
   st_drop_geometry() %>%
   write_csv(use_network_path(
-    "2024 SES Index/data/raw_data/remoteness/bc_address_with_da.csv"
+    file.path(year_config$project_folder, year_config$remoteness$address_with_da_csv)
   ))
 
 
@@ -309,7 +313,7 @@ avg_dist_drvtime_by_da_service %>%
 
 avg_dist_drvtime_by_da_service %>%
   write_csv(use_network_path(
-    "2024 SES Index/data/output/remoteness/avg_dist_drvtime_by_da_facility.csv"
+    file.path(year_config$project_folder, year_config$remoteness$avg_dist_drvtime_csv)
   ))
 
 
@@ -402,7 +406,7 @@ CSD_REMOTENESS_BY_FACILITY %>%
 
 CSD_REMOTENESS_BY_FACILITY %>%
   write_csv(use_network_path(
-    "2024 SES Index/data/output/remoteness/CSD_REMOTENESS_BY_FACILITY.csv"
+    file.path(year_config$project_folder, year_config$remoteness$csd_remoteness_csv)
   ))
 
 

--- a/src/11_output_CISV_CISR_CIMD.R
+++ b/src/11_output_CISV_CISR_CIMD.R
@@ -23,6 +23,10 @@ source("./src/utils.R") # get the functions for plotting maps and retrieve table
 config <- config::get()
 # use this config <- config::get(config = "development" ) to switch to development environment.
 
+# Year-sensitive refresh parameters (download URLs, data folders) — ADR-0005
+source("R/config.R")
+year_config <- load_year_config()
+
 # Extract settings from config
 
 lan_path <- config$lan_path
@@ -41,14 +45,14 @@ province = "British Columbia"
 # check if csv file already exists
 CISR_csv_folder = file.path(
   config::get("lan_path"),
-  "2024 SES Index/data/raw_data/StatsCAN_CISR_CISV_CIMD/CISR_CISV/"
+  file.path(year_config$project_folder, year_config$cisr_cisv_folder)
 )
 CISR_csv_file = file.path(CISR_csv_folder, "cisr_scores_quintiles-eng.csv")
 
 
 # Download CISR data
 cisr_data <- download_and_process_dataset(
-  url = "https://www150.statcan.gc.ca/pub/45-20-0001/2025001/csv/cisr-eng.zip",
+  url = year_config$cisr_url,
   csv_folder = CISR_csv_folder,
   file_name = "cisr_scores_quintiles-eng.csv"
 ) %>%
@@ -96,14 +100,14 @@ write_csv(cisr_data_dict, file.path(CISR_csv_folder, "cisr_data_dict.csv"))
 # check if csv file already exists
 CISV_csv_folder = file.path(
   config::get("lan_path"),
-  "2024 SES Index/data/raw_data/StatsCAN_CISR_CISV_CIMD/CISR_CISV/"
+  file.path(year_config$project_folder, year_config$cisr_cisv_folder)
 )
 CISV_csv_file = file.path(CISR_csv_folder, "cisv_scores_quintiles-eng.csv")
 
 
 # Download CISR data
 cisv_data <- download_and_process_dataset(
-  url = "https://www150.statcan.gc.ca/pub/45-20-0001/2025001/csv/cisv-eng.zip",
+  url = year_config$cisv_url,
   csv_folder = CISV_csv_folder,
   file_name = "cisv_scores_quintiles-eng.csv",
   filter_pattern = "cisv_scores_quintiles"
@@ -161,14 +165,14 @@ write_csv(cisv_data_dict, file.path(CISV_csv_folder, "cisv_data_dict.csv"))
 # check if csv file already exists
 CIMD_csv_folder = file.path(
   config::get("lan_path"),
-  "2024 SES Index/data/raw_data/StatsCAN_CISR_CISV_CIMD/CIMD/"
+  file.path(year_config$project_folder, year_config$cimd_folder)
 )
 CIMD_csv_file = file.path(CIMD_csv_folder, "bc_scores_quintiles_EN.csv")
 
 
 # Download CISR data
 cidm_data <- download_and_process_dataset(
-  url = "https://www150.statcan.gc.ca/pub/45-20-0001/2023001/csv/bc_scores_quintiles_csv-eng.zip.zip",
+  url = year_config$cimd_url,
   csv_folder = CIMD_csv_folder,
   file_name = "bc_scores_quintiles_EN.csv",
   filter_pattern = "sbc_scores_quintiles_EN"

--- a/src/12_output_CHSA_DA_lookup.R
+++ b/src/12_output_CHSA_DA_lookup.R
@@ -81,8 +81,12 @@ config <- config::get()
 # use this config <- config::get(config = "development" ) to switch to development environment.
 
 # Shared helpers (ADR-0009): connect_db + the extracted CHSADA weighting
+source("R/config.R")
 source("R/db.R")
 source("R/transformations.R")
+
+# Year-sensitive refresh parameters (CHSA lookup ranges, BCDC record IDs)
+year_config <- load_year_config()
 
 # Extract settings from config
 gcs_table <- config$tables$gcs
@@ -177,7 +181,7 @@ gcs_data |>
 # it may cause problem later
 
 # start working on DB2021 and CHSA
-# each row/year is expanded to 2019:2023
+# each row/year is expanded to the configured 2021-census-era range
 gcs_chsa_db_lookup_2021 <- gcs_data %>%
   count(
     CHSA,
@@ -185,7 +189,9 @@ gcs_chsa_db_lookup_2021 <- gcs_data %>%
     DBUID = DB_2021,
     name = "CNT_POSTALCODE"
   ) %>%
-  tidyr::expand_grid(YEAR = 2019:2023) %>%
+  tidyr::expand_grid(
+    YEAR = year_config$chsa_lookup$range_2021_census[1]:year_config$chsa_lookup$range_2021_census[2]
+  ) %>%
   left_join(chsa_data)
 
 
@@ -197,7 +203,9 @@ gcs_chsa_db_lookup_2016 <- gcs_data %>%
     DBUID = DB_2016,
     name = "CNT_POSTALCODE"
   ) %>%
-  tidyr::expand_grid(YEAR = 2016:2018) %>%
+  tidyr::expand_grid(
+    YEAR = year_config$chsa_lookup$range_2016_census[1]:year_config$chsa_lookup$range_2016_census[2]
+  ) %>%
   left_join(chsa_data)
 
 
@@ -257,7 +265,9 @@ db_da_chsa_2021_jonathan |> glimpse()
 # 52423 DBs
 
 db_da_chsa_2016_2023_jonathan <- db_da_chsa_2021_jonathan |>
-  expand_grid(YEAR = 2016:2023) |>
+  expand_grid(
+    YEAR = year_config$chsa_lookup$range_db_pop[1]:year_config$chsa_lookup$range_db_pop[2]
+  ) |>
   select(YEAR, CHSA, CHSA_NAME, DBUID)
 
 db_da_chsa_2016_2023_jonathan |> glimpse()
@@ -427,7 +437,8 @@ bc_db_da_chsa_pop <- bc_db_da_chsa_pop |>
     POPULATION = if_else(
       DBUID %in%
         (db_multiple_chsa |> distinct(DBUID) |> pull(DBUID)) &
-        (YEAR %in% 2016:2018),
+        (YEAR %in%
+          year_config$chsa_lookup$range_2016_census[1]:year_config$chsa_lookup$range_2016_census[2]),
       POPULATION / 2,
       POPULATION
     )
@@ -532,7 +543,7 @@ write_csv(
 
 db_da_chsa_pop_csv_folder = file.path(
   config::get("lan_path"),
-  "2024 SES Index/data/raw_data/chsa_da_crosswalk/"
+  file.path(year_config$project_folder, year_config$chsa_da_crosswalk_folder)
 )
 
 write_csv(

--- a/src/14_connectivity.R
+++ b/src/14_connectivity.R
@@ -473,7 +473,7 @@ log_info("==== PART 2: Load CITZ data at PHH_ID level ====")
 # ---- 5.1) Load CITZ micro-data ----
 citz_path <- file.path(
   lan_path,
-  "2024 SES Index/data/raw_data/internet_connectivity/CITZ",
+  file.path(year_config$project_folder, year_config$citz_folder),
   "CITZ_SHR_Connectivity_Status_January2025.csv"
 )
 log_info("Loading CITZ data: {citz_path}")

--- a/src/15_remove_geo_suppression_ids.R
+++ b/src/15_remove_geo_suppression_ids.R
@@ -40,6 +40,10 @@ source("./src/utils.R")
 # Load configuration
 config <- config::get()
 
+# Year-sensitive refresh parameters (output_year, indig CSD types) — ADR-0005
+source("R/config.R")
+year_config <- load_year_config()
+
 cancensus::set_cancensus_cache_path(
   config$file_path$cancensus_cache_path
 )
@@ -50,14 +54,13 @@ cancensus::set_cancensus_cache_path(
 #-------------------------------------------------------------------------------------------
 
 # Output path for data catalogue products
-output_year <- 2023 # Set year parameter here
+output_year <- year_config$output_year # [year-bearing] catalogue output year
 
 
 output_path <- file.path(
   config$lan_path,
-  "2024 SES Index",
-  "bc data catalogue",
-  "Data Catalogue final products",
+  year_config$project_folder,
+  year_config$data_catalogue_folder,
   as.character(output_year)
 )
 
@@ -158,7 +161,7 @@ bc_csds |> count(CSDTYPE)
 # S-É: 	Indian settlement / Établissement indien
 # TAL = Tla'amin Lands
 # TWL – Tsawwassen Lands
-indig_csd_types <- c('IRI', 'IGD', 'NL', 'S-É', 'TAL', 'TWL')
+indig_csd_types <- year_config$indig_csd_types
 
 cat("Indigenous CSD types being suppressed:\n")
 cat("  ", paste(indig_csd_types, collapse = ", "), "\n\n")

--- a/src/17_data_preparation_for_powerbi.R
+++ b/src/17_data_preparation_for_powerbi.R
@@ -29,6 +29,10 @@ source("./src/utils.R") # Load configuration using config package
 # This will automatically look for a file named config.yml in the current and parent directory
 config <- config::get()
 
+# Year-sensitive refresh parameters (index exports, geo layers) — ADR-0005
+source("R/config.R")
+year_config <- load_year_config()
+
 bc_ses_project_lan_path = config$lan_path
 
 #################################################################
@@ -121,7 +125,7 @@ bc_ses_project_lan_path = config$lan_path
 chsa <- geojson_read(
   file.path(
     bc_ses_project_lan_path,
-    "2024 SES Index\\data\\other\\StatsCAN_sgc\\chsa_2022_wgs.json"
+    file.path(year_config$project_folder, year_config$chsa_geojson)
   ),
   what = "sp"
 )
@@ -230,7 +234,7 @@ writeLines(
   topojson_data,
   file.path(
     bc_ses_project_lan_path,
-    "2024 SES Index\\data\\other\\StatsCAN_sgc\\lower_mainland_chsa.json"
+    file.path(year_config$project_folder, year_config$lower_mainland_chsa_json)
   )
 )
 #
@@ -264,7 +268,7 @@ chsa_tbl |> glimpse()
 # create a long format table by staking CSD and CHSA level indices
 data_path <- file.path(
   bc_ses_project_lan_path,
-  "2024 SES Index/exports/2025-07-31-initial-index-results"
+  file.path(year_config$project_folder, year_config$index_exports_path)
 )
 
 index_data_path <- list.files(data_path, full.names = TRUE) |>
@@ -461,13 +465,13 @@ index_contribution_data_combined |>
 # Load data dictionary
 longitudinal_model_input_data_dictionary <- read_csv(file.path(
   bc_ses_project_lan_path,
-  "2024 SES Index/exports/2025-07-31-initial-index-results",
+  file.path(year_config$project_folder, year_config$index_exports_path),
   "longitudinal_model_input_data_dictionary_2025-07-21.csv"
 ))
 
 detail_model_input_data_dictionary <- read_csv(file.path(
   bc_ses_project_lan_path,
-  "2024 SES Index/exports/2025-07-31-initial-index-results",
+  file.path(year_config$project_folder, year_config$index_exports_path),
   "robust_model_input_data_dictionary_2025-07-21.csv"
 ))
 
@@ -704,7 +708,7 @@ sgc_structure_csd_BC <- sgc_structure_csd |>
 sgc_structure_csd_BC |>
   readr::write_csv(file.path(
     bc_ses_project_lan_path,
-    "2024 SES Index\\data\\other\\StatsCAN_sgc\\sgc_structure_csd_BC.csv"
+    file.path(year_config$project_folder, year_config$sgc_structure_csv)
   ))
 
 #########################################################################################

--- a/src/18_trend_ses.R
+++ b/src/18_trend_ses.R
@@ -21,12 +21,16 @@ source("./src/utils.R") # Load configuration using config package
 # This will automatically look for a file named config.yml in the current and parent directory
 config <- config::get()
 
+# Year-sensitive refresh parameters (index exports, CSD shapefile) — ADR-0005
+source("R/config.R")
+year_config <- load_year_config()
+
 #Setting paths
 bc_ses_project_lan_path <- config$lan_path
 
 bc_ses_exports <- file.path(
   bc_ses_project_lan_path,
-  "2024 SES Index/exports/2025-07-31-initial-index-results"
+  file.path(year_config$project_folder, year_config$index_exports_path)
 )
 # get the trend of total index
 longitudinal_total_index <- read_csv(file.path(
@@ -70,5 +74,5 @@ library(tmap)
 # read in the shapefile for CSDs
 csd_sf <- st_read(file.path(
   bc_ses_project_lan_path,
-  "2021 Census Boundary Files - 2023 Release/csd_2021.shp"
+  file.path(year_config$project_folder, year_config$csd_boundary_2021_shp)
 ))  


### PR DESCRIPTION
…005)

config_year.yml extended with the refresh_year sentinel (2026) and all audit-tracked values: year windows (crime/wildfire/population/CHSA ranges, output_year), LAN paths grouped by script domain, download URLs, BC Data Catalogue record IDs, and the indigenous CSD type codes. validate_refresh() (GCS-table-vs-refresh_year only, per the data/work-year split) runs via load_year_config() at every script start.

12 scripts migrated off hardcoded values: 03, 05, 06a, 06b, 08, 09, 11, 12, 14, 15, 17, 18. Only utils.R's two plot-output paths remain inline (audit: keep-inline class). Fixes two latent bugs found during migration:
- 06a used lan_path without ever assigning it (relied on session leakage)
- 05 had the same lan_path leak

All 12 files R-parse-verified; config round-trips via config::get; the indig CSD codes preserved exactly (incl. accented S-E). LAN re-runs needed to confirm identical outputs.