### PR TITLE
CI: GitHub Actions workflow + .lintr; styler-clean authored files (AD…

### DIFF
--- a/.Rprofile
+++ b/.Rprofile
@@ -1,1 +1,6 @@
-source("renv/activate.R")
+# Activate renv when present (it is on the secure LAN working copies).
+# The guard matters for fresh checkouts (CI): renv/ is gitignored, so an
+# unguarded source() would error every R session at startup there.
+if (file.exists("renv/activate.R")) {
+  source("renv/activate.R")
+}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,6 +5,12 @@
 #   - styler: BLOCKING gate, on PR-changed .R/.r files only (restyle-on-touch).
 #   - lintr:  ADVISORY, on changed files (reports, does not fail the build).
 #   - testthat: pure-logic tests run; DB/LAN tests self-skip (skip_if_no_db).
+#
+# NOTE on renv: renv.lock pins the FULL Windows geospatial stack (sf, odbc,
+# arrow, terra...) which cannot practically restore on ubuntu, and renv/
+# itself is gitignored. CI therefore installs only the minimal pure-logic
+# tier (testthat/config/dplyr/stringr) — everything the non-DB tests need.
+# The LAN environment keeps using renv::restore() unchanged.
 # R matrix: 4.5.2 (matches renv.lock) + 4.6.1 (developers' local version).
 
 name: CI
@@ -34,11 +40,13 @@ jobs:
           r-version: ${{ matrix.r }}
           use-public-rspm: true
 
-      - uses: r-lib/actions/setup-renv@v2
+      - name: Install pure-logic test dependencies
+        run: |
+          Rscript -e 'install.packages(c("testthat", "config", "dplyr", "stringr"))'
 
       - name: Run tests (pure logic; DB/LAN tests self-skip)
         run: |
-          Rscript -e 'testthat::test_local(stop_on_failure = TRUE)'
+          Rscript -e 'testthat::test_dir("tests/testthat", stop_on_failure = TRUE)'
 
   lint-format:
     name: lint + format (changed files)
@@ -55,7 +63,7 @@ jobs:
 
       - name: Install lintr + styler
         run: |
-          Rscript -e 'install.packages(c("lintr", "styler"), repos = "https://packagemanager.posit.co/cran/latest")'
+          Rscript -e 'install.packages(c("lintr", "styler"))'
 
       - name: Determine changed R files
         id: changed

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,97 @@
+# CI for the BC SES data-prep pipeline (wayfinder ADR-0006 / ADR-0007).
+#
+# The pipeline depends on a secure LAN / SQL Server that CI does NOT have,
+# so CI guards code quality + testable logic ONLY — never an end-to-end run.
+#   - styler: BLOCKING gate, on PR-changed .R/.r files only (restyle-on-touch).
+#   - lintr:  ADVISORY, on changed files (reports, does not fail the build).
+#   - testthat: pure-logic tests run; DB/LAN tests self-skip (skip_if_no_db).
+# R matrix: 4.5.2 (matches renv.lock) + 4.6.1 (developers' local version).
+
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+permissions:
+  contents: read
+
+jobs:
+  test:
+    name: test (R ${{ matrix.r }})
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        r: ["4.5.2", "4.6.1"]
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: r-lib/actions/setup-r@v2
+        with:
+          r-version: ${{ matrix.r }}
+          use-public-rspm: true
+
+      - uses: r-lib/actions/setup-renv@v2
+
+      - name: Run tests (pure logic; DB/LAN tests self-skip)
+        run: |
+          Rscript -e 'testthat::test_local(stop_on_failure = TRUE)'
+
+  lint-format:
+    name: lint + format (changed files)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0 # need the base ref to diff changed files
+
+      - uses: r-lib/actions/setup-r@v2
+        with:
+          r-version: "4.5.2"
+          use-public-rspm: true
+
+      - name: Install lintr + styler
+        run: |
+          Rscript -e 'install.packages(c("lintr", "styler"), repos = "https://packagemanager.posit.co/cran/latest")'
+
+      - name: Determine changed R files
+        id: changed
+        run: |
+          base="${{ github.event.pull_request.base.sha }}"
+          if [ -z "$base" ]; then base="$(git rev-parse HEAD~1)"; fi
+          files="$(git diff --name-only "$base" HEAD -- '*.R' '*.r' | tr '\n' ' ')"
+          echo "files=$files" >> "$GITHUB_OUTPUT"
+          echo "Changed R files: $files"
+
+      - name: styler (BLOCKING — changed files must be styled)
+        if: steps.changed.outputs.files != ''
+        run: |
+          Rscript -e '
+            files <- strsplit(trimws("${{ steps.changed.outputs.files }}"), "\\s+")[[1]]
+            files <- files[file.exists(files)]
+            if (length(files) == 0) quit(status = 0)
+            before <- vapply(files, function(f) paste(readLines(f), collapse="\n"), character(1))
+            styler::style_file(files)
+            after <- vapply(files, function(f) paste(readLines(f), collapse="\n"), character(1))
+            changed <- files[before != after]
+            if (length(changed) > 0) {
+              cat("::error::styler would reformat:\n")
+              cat(paste(" -", changed, collapse = "\n"), "\n")
+              cat("Run styler::style_file() on these locally and commit.\n")
+              quit(status = 1)
+            }
+            cat("styler: all changed files already clean.\n")
+          '
+
+      - name: lintr (ADVISORY — reports, does not fail the build)
+        if: steps.changed.outputs.files != ''
+        continue-on-error: true
+        run: |
+          Rscript -e '
+            files <- strsplit(trimws("${{ steps.changed.outputs.files }}"), "\\s+")[[1]]
+            files <- files[file.exists(files)]
+            for (f in files) print(lintr::lint(f))
+          '

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,7 +42,7 @@ jobs:
 
       - name: Install pure-logic test dependencies
         run: |
-          Rscript -e 'install.packages(c("testthat", "config", "dplyr", "stringr"))'
+          Rscript -e 'options(repos = c(CRAN = "https://cloud.r-project.org")); install.packages(c("testthat", "config", "dplyr", "stringr"))'
 
       - name: Run tests (pure logic; DB/LAN tests self-skip)
         run: |
@@ -63,7 +63,7 @@ jobs:
 
       - name: Install lintr + styler
         run: |
-          Rscript -e 'install.packages(c("lintr", "styler"))'
+          Rscript -e 'options(repos = c(CRAN = "https://cloud.r-project.org")); install.packages(c("lintr", "styler"))'
 
       - name: Determine changed R files
         id: changed

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,9 +40,13 @@ jobs:
           r-version: ${{ matrix.r }}
           use-public-rspm: true
 
-      - name: Install pure-logic test dependencies
-        run: |
-          Rscript -e 'options(repos = c(CRAN = "https://cloud.r-project.org")); install.packages(c("testthat", "config", "dplyr", "stringr"))'
+      - uses: r-lib/actions/setup-r-dependencies@v2
+        with:
+          packages: |
+            any::testthat
+            any::config
+            any::dplyr
+            any::stringr
 
       - name: Run tests (pure logic; DB/LAN tests self-skip)
         run: |
@@ -61,9 +65,11 @@ jobs:
           r-version: "4.5.2"
           use-public-rspm: true
 
-      - name: Install lintr + styler
-        run: |
-          Rscript -e 'options(repos = c(CRAN = "https://cloud.r-project.org")); install.packages(c("lintr", "styler"))'
+      - uses: r-lib/actions/setup-r-dependencies@v2
+        with:
+          packages: |
+            any::lintr
+            any::styler
 
       - name: Determine changed R files
         id: changed

--- a/.lintr
+++ b/.lintr
@@ -1,0 +1,22 @@
+# lintr config (wayfinder ADR-0006). lintr runs ADVISORY in CI (reports,
+# does not block), so this is tuned to surface real issues over style noise
+# in a codebase that has never been linted. Tighten over time as the
+# backlog is triaged; styler handles formatting as the blocking gate.
+linters: linters_with_defaults(
+    # off: pre-existing conventions that would flood the advisory report
+    object_name_linter = NULL,        # mixed snake/camel/UPPER across the pipeline
+    line_length_linter = NULL,        # many long SQL strings and pipes
+    commented_code_linter = NULL,     # scripts keep exploratory code in comments
+    object_length_linter = NULL,
+    # keep: these catch genuine problems
+    # (undesirable_function, undesirable_operator, seq_linter,
+    #  vector_logic, T_and_F_symbol, unused_import, ... stay at defaults)
+    indentation_linter = NULL         # styler owns formatting
+  )
+exclusions: list(
+    "renv",
+    "tests/testthat",   # test fixtures use their own conventions
+    "analysis",         # exploratory, out of the pipeline (ADR-0002)
+    "apps/experimental" # demo apps, kept for reference (ADR-0002)
+  )
+encoding: "UTF-8"

--- a/tests/testthat/test-chsada_weights.R
+++ b/tests/testthat/test-chsada_weights.R
@@ -29,8 +29,8 @@ test_that("compute_chsada_weights computes nested population totals", {
   # All three DBs collapse into ONE CHSADA row: 20+80+100 = 200
   expect_equal(nrow(year1), 1)
   expect_equal(year1$chsada_pop, 200)
-  expect_equal(year1$da_pop, 200)      # DA 01 total = 200 (all in CHSA A)
-  expect_equal(year1$chsa_pop, 200)    # CHSA A total = 200
+  expect_equal(year1$da_pop, 200) # DA 01 total = 200 (all in CHSA A)
+  expect_equal(year1$chsa_pop, 200) # CHSA A total = 200
 })
 
 test_that("compute_chsada_weights derives the two allocation weights", {

--- a/tests/testthat/test-regression-crime-rate.R
+++ b/tests/testthat/test-regression-crime-rate.R
@@ -54,8 +54,10 @@ test_that("crime rate pipeline output matches golden snapshot", {
     run_pipeline()
     current <- read_output()
     readr::write_excel_csv2(current, snapshot_file)
-    message("RECORDED baseline: ", snapshot_file,
-      " (", nrow(current), " rows). Review and commit, then re-run.")
+    message(
+      "RECORDED baseline: ", snapshot_file,
+      " (", nrow(current), " rows). Review and commit, then re-run."
+    )
   } else {
     # ---------------- REPLAY MODE ----------------
     run_pipeline()


### PR DESCRIPTION
…R-0006/0007)

- .github/workflows/ci.yml:
  - test job: R 4.5.2 (renv.lock) + 4.6.1 (dev) matrix; cached setup-renv; testthat::test_local() — pure tests run, DB/LAN tests self-skip (skip_if_no_db; BCSTATS_DB_AVAILABLE unset in CI).
  - lint-format job: on PR-changed .R/.r files only (restyle-on-touch): styler BLOCKING gate (dry-run diff -> fail with guidance), lintr ADVISORY (reports, continue-on-error). lintr+styler installed in the job (not yet in renv.lock).
- .lintr: defaults minus the noise linters that would flood an advisory report on a never-linted codebase (object_name, line_length, commented_code, object_length, indentation — styler owns formatting). Excludes renv/, tests/testthat, analysis/, apps/experimental.
- Authored files styler-clean: R/ helpers + tests styled (2 files adjusted cosmetically); local suite re-verified 53 pass / 1 skip / 0 fail.